### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,34 +6,34 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-digitalSandbox			KEYWORD1
+digitalSandbox	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 setupSandbox	KEYWORD2
-setRGB			KEYWORD2
-ledOn			KEYWORD2
-ledOff	   		KEYWORD2
-leds			KEYWORD2
-blink			KEYWORD2
-readSlider		KEYWORD2 
-readSound		KEYWORD2
-readLight		KEYWORD2
-readTemp		KEYWORD2
-readButton		KEYWORD2
-readSwitch 		KEYWORD2
+setRGB	KEYWORD2
+ledOn	KEYWORD2
+ledOff	KEYWORD2
+leds	KEYWORD2
+blink	KEYWORD2
+readSlider	KEYWORD2 
+readSound	KEYWORD2
+readLight	KEYWORD2
+readTemp	KEYWORD2
+readButton	KEYWORD2
+readSwitch	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-TEMP		LITERAL1
-LIGHT		LITERAL1
-SOUND		LITERAL1
-SLIDER		LITERAL1
-RED			LITERAL1
-GREEN		LITERAL1
-BLUE		LITERAL1
-AREF		LITERAL1
+TEMP	LITERAL1
+LIGHT	LITERAL1
+SOUND	LITERAL1
+SLIDER	LITERAL1
+RED	LITERAL1
+GREEN	LITERAL1
+BLUE	LITERAL1
+AREF	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords